### PR TITLE
Follow up of keras bug fix

### DIFF
--- a/pathint/utils.py
+++ b/pathint/utils.py
@@ -79,7 +79,7 @@ def extract_weight_changes(weights, update_ops):
 
 
 def compute_updates(opt, loss, weights):
-    update_ops = opt.get_updates(weights, [], loss)
+    update_ops = opt.get_updates(weights, loss)
     deltas, new_update_op = extract_weight_changes(weights, update_ops)
     grads = tf.gradients(loss, weights)
     # Make sure  that deltas are computed _before_ the weight is updated


### PR DESCRIPTION
The [] was there because in the version before got an argument constraint, because this is gone now, the empty array has to be removed as well. Maybe, that was causing the different results?